### PR TITLE
Fixes CMakeLists.txt to properly import the paths into any location. pico-sdk compatible.

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,14 +1,14 @@
 
 file(GLOB SOURCES "${CMAKE_CURRENT_LIST_DIR}/../src/*.cpp")
 
-add_library(TaskManagerIO ${SOURCES})
+add_library(TaskManagerIO INTERFACE ${SOURCES})
 
 target_compile_definitions(TaskManagerIO
-        PUBLIC BUILD_FOR_PICO_CMAKE=1 BUILD_PICO_FORCE_UART=1 IO_LOGGING_DEBUG=1
+        INTERFACE BUILD_FOR_PICO_CMAKE=1 BUILD_PICO_FORCE_UART=1 IO_LOGGING_DEBUG=1
 )
 
-target_include_directories(TaskManagerIO PUBLIC
+target_include_directories(TaskManagerIO INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/../src
 )
 
-target_link_libraries(TaskManagerIO PUBLIC TcMenuLog pico_stdlib pico_sync)
+target_link_libraries(TaskManagerIO INTERFACE TcMenuLog pico_stdlib pico_sync)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,14 +1,18 @@
+cmake_minimum_required(VERSION 3.13)
 
-file(GLOB SOURCES "${CMAKE_CURRENT_LIST_DIR}/../src/*.cpp")
-
-add_library(TaskManagerIO ${SOURCES})
+add_library(TaskManagerIO 
+        ../src/SimpleSpinLock.cpp
+        ../src/TaskManagerIO.cpp
+        ../src/TaskTypes.cpp
+        ../src/TmLongSchedule.cpp
+)
 
 target_compile_definitions(TaskManagerIO
         PUBLIC BUILD_FOR_PICO_CMAKE=1 BUILD_PICO_FORCE_UART=1 IO_LOGGING_DEBUG=1
 )
 
 target_include_directories(TaskManagerIO PUBLIC
-        ${CMAKE_CURRENT_LIST_DIR}/../src
+        ../src
 )
 
 target_link_libraries(TaskManagerIO PUBLIC TcMenuLog pico_stdlib pico_sync)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,16 +1,14 @@
-add_library(TaskManagerIO
-        ../src/SimpleSpinLock.cpp
-        ../src/TaskManagerIO.cpp
-        ../src/TaskTypes.cpp
-        ../src/TmLongSchedule.cpp
-)
+
+file(GLOB SOURCES "${CMAKE_CURRENT_LIST_DIR}/../src/*.cpp")
+
+add_library(TaskManagerIO ${SOURCES})
 
 target_compile_definitions(TaskManagerIO
         PUBLIC BUILD_FOR_PICO_CMAKE=1 BUILD_PICO_FORCE_UART=1 IO_LOGGING_DEBUG=1
 )
 
 target_include_directories(TaskManagerIO PUBLIC
-        ${PROJECT_SOURCE_DIR}/lib/TaskManagerIO/src
+        ${CMAKE_CURRENT_LIST_DIR}/../src
 )
 
 target_link_libraries(TaskManagerIO PUBLIC TcMenuLog pico_stdlib pico_sync)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,14 +1,14 @@
 
 file(GLOB SOURCES "${CMAKE_CURRENT_LIST_DIR}/../src/*.cpp")
 
-add_library(TaskManagerIO INTERFACE ${SOURCES})
+add_library(TaskManagerIO ${SOURCES})
 
 target_compile_definitions(TaskManagerIO
-        INTERFACE BUILD_FOR_PICO_CMAKE=1 BUILD_PICO_FORCE_UART=1 IO_LOGGING_DEBUG=1
+        PUBLIC BUILD_FOR_PICO_CMAKE=1 BUILD_PICO_FORCE_UART=1 IO_LOGGING_DEBUG=1
 )
 
-target_include_directories(TaskManagerIO INTERFACE
+target_include_directories(TaskManagerIO PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/../src
 )
 
-target_link_libraries(TaskManagerIO INTERFACE TcMenuLog pico_stdlib pico_sync)
+target_link_libraries(TaskManagerIO PUBLIC TcMenuLog pico_stdlib pico_sync)

--- a/src/BasicInterruptAbstraction.h
+++ b/src/BasicInterruptAbstraction.h
@@ -6,8 +6,8 @@
 #ifndef TASKMANAGERIO_BASICINTERRUPTABSTRACTION_H
 #define TASKMANAGERIO_BASICINTERRUPTABSTRACTION_H
 
-#include <TaskPlatformDeps.h>
-#include <TaskManagerIO.h>
+#include "TaskPlatformDeps.h"
+#include "TaskManagerIO.h"
 
 #ifdef IOA_USE_ARDUINO
 

--- a/src/TaskBlock.h
+++ b/src/TaskBlock.h
@@ -6,8 +6,8 @@
 #ifndef _TASKMANAGERIO_TASKBLOCK_H_
 #define _TASKMANAGERIO_TASKBLOCK_H_
 
-#include <TaskPlatformDeps.h>
-#include <TaskTypes.h>
+#include "TaskPlatformDeps.h"
+#include "TaskTypes.h"
 
 /**
  * @file TaskBlock.h

--- a/src/TmLongSchedule.h
+++ b/src/TmLongSchedule.h
@@ -11,7 +11,7 @@
  * @brief long schedule support for task manager
  */
 
-#include <TaskManagerIO.h>
+#include "TaskManagerIO.h"
 
 /**
  * A task manager task that can be scheduled safely in hours and days. If you need more than this, you'll probably need to


### PR DESCRIPTION
In trying out the tcMenu, i found it not easy to use as the libraries had to be exported and pushed into very specific locations. Having done cmake libraries for the pico-sdk, I was able to make the required changes to properly import the sdk using cmake.

The `CMakeLists.txt` has had the paths fixed,  so that it can be used with the `libraries.cmake` that is in the `tcLibraryDev` or `FetchContent`  from cmake.